### PR TITLE
format exponents

### DIFF
--- a/Sequencing/README.md
+++ b/Sequencing/README.md
@@ -132,10 +132,10 @@ Q = -10 log<sub>10<sub>(P<sub>e</sub>)
 Where Q is the quality score, and P<sub>e</sub> is the probability of error in the base call. Quality scores range from 0 to 99, although 99 is usually used to mean that you have artificially inserted a sequence at that position (e.g. through manually editing the sequence). The meaning of quality scores are shown in the two tables below.
 
 
-* Phred 10: 1 x 10<sup>1</sup> chance that the base is wrong
-* Phred 20: 1 x 10<sup>2</sup> chance that the base is wrong
-* Phred 30: 1 x 10<sup>3</sup> chance that the base is wrong
-* Phred 40: 1 x 10<sup>4</sup> chance that the base is wrong
+* Phred 10: 1 x 10<sup style="vertical-align: 50%; font-size:60%">1</sup> chance that the base is wrong
+* Phred 20: 1 x 10<sup style="vertical-align: 50%; font-size:60%">2</sup> chance that the base is wrong
+* Phred 30: 1 x 10<sup style="vertical-align: 50%; font-size:60%">3</sup> chance that the base is wrong
+* Phred 40: 1 x 10<sup style="vertical-align: 50%; font-size:60%">4</sup> chance that the base is wrong
 
 Alternatively:
 


### PR DESCRIPTION
I noticed that wherever you have style.css, it removes the formatting for `<sup>` which wasn't really a problem until the phred scores.  I hope this helps, or if not this, then I'd remove `<sup>` from style.css where it removes the formatting from a lot of tags.

This formatting bug does not appear on github markdown pages but does appear on the github pages hosted site.